### PR TITLE
CE-486: Add "bug report" action

### DIFF
--- a/src/actions.txt
+++ b/src/actions.txt
@@ -21,3 +21,4 @@ StepLeft
 StepRight
 CheatDive
 Screenshot
+BugReport

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -81,6 +81,7 @@ private:
   [[nodiscard]] std::unique_ptr<loader::trx::Glidos> loadGlidosPack() const;
 
   void makeScreenshot();
+  void takeBugReport(world::World& world);
 
 public:
   explicit Engine(std::filesystem::path userDataPath,

--- a/src/engine/engineconfig.cpp
+++ b/src/engine/engineconfig.cpp
@@ -53,6 +53,7 @@ std::vector<NamedInputMappingConfig> getDefaultMappings()
         {GlfwKey::Q, Action::StepLeft},
         {GlfwKey::E, Action::StepRight},
         {GlfwKey::F12, Action::Screenshot},
+        {GlfwKey::F1, Action::BugReport},
         {GlfwKey::F10, Action::CheatDive} // only available in debug builds
       },
     },

--- a/src/engine/world/world.cpp
+++ b/src/engine/world/world.cpp
@@ -1060,17 +1060,22 @@ void World::load(const std::optional<size_t>& slot)
   getPresenter().disableScreenOverlay();
 }
 
+void World::save(const std::filesystem::path& filename,bool isQuicksave)
+{
+  BOOST_LOG_TRIVIAL(info) << "Save " << filename;
+  serialization::YAMLDocument<false> doc{filename};
+  SavegameMeta meta{std::filesystem::relative(m_levelFilename, m_engine.getAssetDataPath()).string(),
+                    isQuicksave ? _("Quicksave") : m_title};
+  doc.save("meta", meta, meta);
+  doc.save("data", *this, *this);
+  doc.write();
+}
+
 void World::save(const std::optional<size_t>& slot)
 {
   getPresenter().drawLoadingScreen(_("Saving..."));
   const auto filename = m_engine.getSavegamePath(slot);
-  BOOST_LOG_TRIVIAL(info) << "Save " << filename;
-  serialization::YAMLDocument<false> doc{filename};
-  SavegameMeta meta{std::filesystem::relative(m_levelFilename, m_engine.getAssetDataPath()).string(),
-                    slot.has_value() ? m_title : _("Quicksave")};
-  doc.save("meta", meta, meta);
-  doc.save("data", *this, *this);
-  doc.write();
+  save(filename, !slot.has_value());
   getPresenter().disableScreenOverlay();
 }
 

--- a/src/engine/world/world.h
+++ b/src/engine/world/world.h
@@ -243,6 +243,7 @@ public:
   bool cinematicLoop();
   void load(const std::optional<size_t>& slot);
   void save(const std::optional<size_t>& slot);
+  void save(const std::filesystem::path& path, bool isQuicksave);
   [[nodiscard]] std::tuple<std::optional<SavegameInfo>, std::map<size_t, SavegameInfo>> getSavedGames() const;
   [[nodiscard]] bool hasSavedGames() const;
 

--- a/src/hid/names.cpp
+++ b/src/hid/names.cpp
@@ -352,6 +352,8 @@ std::string getName(Action action)
     return /* translators: TR charmap encoding */ pgettext("Action", "Cheat Dive");
   case Action::Screenshot:
     return /* translators: TR charmap encoding */ pgettext("Action", "Screenshot");
+  case Action::BugReport: 
+    return /* translators: TR charmap encoding */ pgettext("Action", "Bug Report");
   }
   BOOST_THROW_EXCEPTION(std::domain_error("action"));
 }

--- a/src/menu/controlswidget.cpp
+++ b/src/menu/controlswidget.cpp
@@ -67,7 +67,7 @@ constexpr const std::array<std::array<std::optional<hid::Action>, 4>, Columns> s
     hid::Action::Save,
     hid::Action::Load,
     hid::Action::Screenshot,
-    std::nullopt,
+    hid::Action::BugReport,
   },
 }};
 


### PR DESCRIPTION
This adds a 'bug report' action (default key F1) that 
- Saves a screenshot
- copies croftengine.log
- saves game in slot SIZE_MAX, copies it as save.yaml and deletes the orriginal
- displays "Bug Report Saved" in the bottom left corner of the screen which disappears after 5 seconds.

these items are saved in $USERDATA/bugreports/$TIMESTAMP