### PR TITLE
Bloom improvements

### DIFF
--- a/share/shaders/fx_bloom.frag
+++ b/share/shaders/fx_bloom.frag
@@ -5,5 +5,5 @@ layout(bindless_sampler) uniform sampler2D u_bloom;
 
 void main()
 {
-    out_color = mix(texture(u_input, fpi.texCoord).rgb, texture(u_bloom, fpi.texCoord).rgb, 0.2);
+    out_color = texture(u_input, fpi.texCoord).rgb + texture(u_bloom, fpi.texCoord).rgb;
 }

--- a/share/shaders/fx_bloom_filter.frag
+++ b/share/shaders/fx_bloom_filter.frag
@@ -1,0 +1,12 @@
+#include "flat_pipeline_interface.glsl"
+#include "fx_input.glsl"
+#include "util.glsl"
+
+void main()
+{
+    const float Offset = 0.0;
+
+    vec3 base = texture(u_input, fpi.texCoord).rgb;
+    float baseLum = clamp((luminanceRgb(base) - Offset) / (1.0 - Offset), 0.0, 1.0);
+    out_color = base * pow(baseLum, 2.0);
+}

--- a/src/render/pass/worldcompositionpass.h
+++ b/src/render/pass/worldcompositionpass.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "render/pass/effectpass.h"
 #include "render/scene/blur.h"
 
 #include <gl/pixel.h>
@@ -30,7 +31,8 @@ class GeometryPass;
 class WorldCompositionPass
 {
 public:
-  explicit WorldCompositionPass(scene::MaterialManager& materialManager,
+  explicit WorldCompositionPass(gsl::not_null<const RenderPipeline*> renderPipeline,
+                                scene::MaterialManager& materialManager,
                                 const RenderSettings& renderSettings,
                                 const glm::ivec2& viewport,
                                 const GeometryPass& geometryPass,
@@ -62,6 +64,8 @@ private:
   gslu::nn_shared<gl::Texture2D<gl::SRGB8>> m_bloomedBuffer;
   gslu::nn_shared<gl::TextureHandle<gl::Texture2D<gl::SRGB8>>> m_bloomedBufferHandle;
   gslu::nn_shared<gl::Framebuffer> m_fb;
+
+  EffectPass<gl::SRGB8> m_bloomFilter;
   gslu::nn_shared<gl::Framebuffer> m_fbBloom;
   render::scene::SeparableBlur<gl::SRGB8> m_bloomBlur1;
   render::scene::SeparableBlur<gl::SRGB8> m_bloomBlur2;

--- a/src/render/renderpipeline.cpp
+++ b/src/render/renderpipeline.cpp
@@ -119,7 +119,7 @@ void RenderPipeline::resize(scene::MaterialManager& materialManager,
   m_portalPass = std::make_shared<pass::PortalPass>(materialManager, m_geometryPass->getDepthBuffer(), m_renderSize);
   m_hbaoPass = std::make_shared<pass::HBAOPass>(materialManager, m_renderSize / 4, *m_geometryPass);
   m_worldCompositionPass = std::make_shared<pass::WorldCompositionPass>(
-    materialManager, m_renderSettings, m_renderSize, *m_geometryPass, *m_portalPass);
+    gsl::not_null{this}, materialManager, m_renderSettings, m_renderSize, *m_geometryPass, *m_portalPass);
   m_uiPass = std::make_shared<pass::UIPass>(materialManager, m_uiSize, m_displaySize);
 
   m_backbufferTextureHandle = std::make_shared<gl::TextureHandle<gl::Texture2D<gl::SRGB8>>>(

--- a/src/render/scene/materialmanager.cpp
+++ b/src/render/scene/materialmanager.cpp
@@ -427,6 +427,17 @@ gslu::nn_shared<Material> MaterialManager::getBloom()
   return m;
 }
 
+gslu::nn_shared<Material> MaterialManager::getBloomFilter()
+{
+  if(m_bloomFilter != nullptr)
+    return gsl::not_null{m_bloomFilter};
+
+  auto m = gsl::make_shared<Material>(m_shaderCache->getBloomFilter());
+  configureForScreenSpaceEffect(*m, false);
+  m_bloomFilter = m;
+  return m;
+}
+
 gslu::nn_shared<Material> MaterialManager::getHBAO()
 {
   if(m_hbao != nullptr)

--- a/src/render/scene/materialmanager.h
+++ b/src/render/scene/materialmanager.h
@@ -51,6 +51,7 @@ public:
   [[nodiscard]] gslu::nn_shared<Material> getUnderwaterMovement();
   [[nodiscard]] gslu::nn_shared<Material> getReflective();
   [[nodiscard]] gslu::nn_shared<Material> getBloom();
+  [[nodiscard]] gslu::nn_shared<Material> getBloomFilter();
 
   [[nodiscard]] gslu::nn_shared<Material> getFlat(bool withAlpha, bool invertY = false, bool withAspectRatio = false);
   [[nodiscard]] gslu::nn_shared<Material> getBackdrop(bool withAlphaMultiplier);
@@ -85,6 +86,7 @@ private:
   std::shared_ptr<Material> m_underwaterMovement{nullptr};
   std::shared_ptr<Material> m_reflective{nullptr};
   std::shared_ptr<Material> m_bloom{nullptr};
+  std::shared_ptr<Material> m_bloomFilter{nullptr};
 
   std::map<bool, gslu::nn_shared<Material>> m_sprite{};
   std::map<bool, gslu::nn_shared<Material>> m_csmDepthOnly{};

--- a/src/render/scene/shadercache.h
+++ b/src/render/scene/shadercache.h
@@ -150,6 +150,11 @@ public:
     return get("flat.vert", "fx_bloom.frag");
   }
 
+  [[nodiscard]] auto getBloomFilter()
+  {
+    return get("flat.vert", "fx_bloom_filter.frag");
+  }
+
   [[nodiscard]] auto getFastGaussBlur(const uint8_t extent, uint8_t blurDim)
   {
     Expects(extent > 0);


### PR DESCRIPTION
This should have been part of #239, but I discovered too late that bloom was basically just blurring the whole image without respecting the actual texel luminance. This change adds an additional pre-blur pass to basically filter out dark texels before blurring it to produce the bloom texture.