### PR TITLE
fix incorrect ammo count on pickup widget when pickups are combined

### DIFF
--- a/src/engine/world/world.h
+++ b/src/engine/world/world.h
@@ -300,7 +300,7 @@ public:
     if(auto it = std::find_if(m_pickupWidgets.begin(), m_pickupWidgets.end(), isSameVirginItem);
        it != m_pickupWidgets.end())
     {
-      it->setCount(it->getCount() + count);
+      it->setCount(count); // at this point the picked up ammo is already in the player's inventory
       return;
     }
     m_pickupWidgets.emplace_back(widgetLifetime, std::move(sprite), count);


### PR DESCRIPTION
I made a mistake when combining pickups that causes the ammo count to be calculated incorrectly.
This fixes that issue (found by Jaaystation) 