### PR TITLE
Fix amount of ammo given when picking up weapons

### DIFF
--- a/src/engine/inventory.cpp
+++ b/src/engine/inventory.cpp
@@ -42,18 +42,21 @@ size_t Inventory::put(const core::TypeId& id, world::World* world, const size_t 
     addWeapon(m_shotgunAmmo);
     if(world != nullptr)
       world->getObjectManager().replaceItems(TR1ItemId::ShotgunSprite, TR1ItemId::ShotgunAmmoSprite, *world);
+    m_shotgunAmmo.addClips(quantity);
     return m_shotgunAmmo.shots;
   case TR1ItemId::MagnumsSprite:
   case TR1ItemId::Magnums:
     addWeapon(m_magnumsAmmo);
     if(world != nullptr)
       world->getObjectManager().replaceItems(TR1ItemId::MagnumsSprite, TR1ItemId::MagnumAmmoSprite, *world);
+    m_magnumsAmmo.addClips(quantity);
     return m_magnumsAmmo.shots;
   case TR1ItemId::UzisSprite:
   case TR1ItemId::Uzis:
     addWeapon(m_uzisAmmo);
     if(world != nullptr)
       world->getObjectManager().replaceItems(TR1ItemId::UzisSprite, TR1ItemId::UziAmmoSprite, *world);
+    m_uzisAmmo.addClips(quantity);
     return m_uzisAmmo.shots;
   case TR1ItemId::ShotgunAmmoSprite:
   case TR1ItemId::ShotgunAmmo:


### PR DESCRIPTION
Just a quick little fix for no ammo being given when picking up weapons
This problem was reported by kittypi314 that picking up guns did not give you any ammo, when in the orriginal game it gave you one reload worth of shots for that weapon.