### PR TITLE
Stop worker threads before closing socket

### DIFF
--- a/src/network/hauntedcoopclient.cpp
+++ b/src/network/hauntedcoopclient.cpp
@@ -122,6 +122,8 @@ struct HauntedCoopClient::ClientImpl
 
   void close()
   {
+    m_ioContext.stop();
+    m_ioService.stop();
     m_socket.close();
   }
 


### PR DESCRIPTION
this prevents ASIO from deadlocking on GetQueuedCompletionStatus() (win32 api) after the socket is closed when join is called on the network thread.

I'm not 100% sure this is the correct solution, but it seems to work when I tested multiple reconnects. 