### PR TITLE
fix failure to build with GCC-13

### DIFF
--- a/src/engine/floordata/types.h
+++ b/src/engine/floordata/types.h
@@ -2,6 +2,7 @@
 
 #include "type_safe/integer.hpp"
 
+#include <cstdint>
 #include <vector>
 
 namespace engine::floordata


### PR DESCRIPTION
the definition of uint16_t is missing

https://gcc.gnu.org/gcc-13/porting_to.html